### PR TITLE
Added SessionID functionality

### DIFF
--- a/chat_app/public/services/messages.js
+++ b/chat_app/public/services/messages.js
@@ -3,7 +3,6 @@ const socket = io('http://localhost:3001');
 
 // Handle successful connection
 socket.on("message", (msg) => {
-  console.log(msg);
   const item = document.createElement('li');
   item.textContent = msg["hi"];
   messages.appendChild(item);
@@ -11,12 +10,18 @@ socket.on("message", (msg) => {
 });
 
 socket.on("connect_message", (msg) => {
-  console.log(msg);
   const item = document.createElement('li');
   item.textContent = msg["hi"];
   messages.appendChild(item);
   window.scrollTo(0, document.body.scrollHeight);
 });
+
+// session listener emitted upon user connecting for the first time
+socket.on("session", ({ sessionId }) => {
+  socket.auth = { sessionId };
+  localStorage.setItem("sessionId", sessionId);
+})
+
 
 // socket.on("message", (msg) => {
 //   console.log(msg);
@@ -35,9 +40,9 @@ socket.on("connect_message", (msg) => {
 
 const disconnectBtn = document.getElementById('disconnect');
 disconnectBtn.addEventListener('click', (e) => {
-	e.preventDefault();
-	socket.disconnect();
-	socket.connect();
+  e.preventDefault();
+  socket.disconnect();
+  socket.connect();
 });
 
 // socket.on("disconnect", (reason) => {

--- a/ws_server/dist/index.js
+++ b/ws_server/dist/index.js
@@ -11,6 +11,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", { value: true });
 const http_1 = require("http");
 const socket_io_1 = require("socket.io");
+const uuid_1 = require("uuid");
 const express = require('express');
 const app = express();
 const cors = require('cors');
@@ -29,34 +30,50 @@ function run() {
         });
     });
 }
+// Express Middleware
 app.use(cors({
     origin: 'http://localhost:3002', // Replace with your client's origin
 }));
 app.use(express.json());
 const PORT = process.env.ENV_PORT || 3001; // this is updated but no ENV_PORT at the moment
+// instantiating new WS server
 const io = new socket_io_1.Server(httpServer, {
     cors: {
         origin: 'http://localhost:3002',
         methods: ['GET', 'POST'],
     },
 });
-app.get('/', (req, res) => {
-    console.log("you've got mail!");
-    res.send('Nice work');
-});
+// WS Server Logic
 let reconnect = false;
+let currentSessions = [];
 const fetchMessages = () => __awaiter(void 0, void 0, void 0, function* () {
     let messageArr = yield MgRequest.find().sort({ _id: -1 }).limit(5);
     return messageArr;
+});
+io.use((socket, next) => {
+    const currentSessionID = socket.handshake.auth.sessionId;
+    console.log("Middleware executed");
+    console.log(currentSessionID);
+    console.log(currentSessions);
+    // if current session exists (re-connect), find that sessionId from the session
+    if (currentSessionID) {
+        const session = currentSessions.find(obj => obj.sessionId === currentSessionID);
+        if (session) {
+            socket.data.sessionId = session.sessionId;
+            return next();
+        }
+    }
+    let randomID = (0, uuid_1.v4)();
+    socket.data.sessionId = randomID;
+    currentSessions.push({ sessionId: randomID });
+    next();
 });
 io.on('connection', (socket) => __awaiter(void 0, void 0, void 0, function* () {
     if (reconnect) {
         console.log('A user re-connected');
         socket.join("room 1");
         let messageArr = yield fetchMessages();
-        console.log(messageArr);
         messageArr.forEach(message => {
-            console.log(message);
             let msg = message.room.roomData;
             socket.emit("connect_message", msg);
         });
@@ -64,21 +81,25 @@ io.on('connection', (socket) => __awaiter(void 0, void 0, void 0, function* () {
     else {
         console.log('A user connected first time');
         socket.join("room 1");
+        socket.emit("session", {
+            sessionId: socket.data.sessionId,
+        });
     }
-    // check to see if this session_id was recently active 
-    // and if their previous disconnection was intentional
     socket.on("disconnecting", (reason) => {
-        console.log(socket.rooms); // Set { ... }
-        console.log(reason);
         if (reason === "client namespace disconnect") {
             reconnect = true;
-            // push an object with session_id and unintentionalDisconnect 
+            // push an object with session_id and unintentionalDisconnect
         }
     });
     socket.on('disconnect', () => {
         console.log('user disconnected');
     });
 }));
+// Backend API
+app.get('/', (req, res) => {
+    console.log("you've got mail!");
+    res.send('Nice work');
+});
 app.put('/api/postman', (req, res) => __awaiter(void 0, void 0, void 0, function* () {
     // accept postman put request
     // publish this request.body data via websocket emit

--- a/ws_server/package.json
+++ b/ws_server/package.json
@@ -21,15 +21,17 @@
   "homepage": "https://github.com/ChristopherBrum/ws_server#readme",
   "dependencies": {
     "cors": "^2.8.5",
-    "express": "^4.18.2",
-    "socket.io": "^4.7.2",
     "dotenv": "^8.2.0",
+    "express": "^4.18.2",
     "mongodb": "^6.1.0",
-    "mongoose": "5.11.15"
+    "mongoose": "5.11.15",
+    "socket.io": "^4.7.2",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@types/cors": "^2.8.13",
     "@types/express": "^4.17.17",
+    "@types/uuid": "^9.0.5",
     "@typescript-eslint/eslint-plugin": "^6.2.0",
     "@typescript-eslint/parser": "^6.2.0",
     "eslint": "^8.45.0",

--- a/ws_server/src/index.ts
+++ b/ws_server/src/index.ts
@@ -2,6 +2,7 @@ import { Request, Response } from "express";
 import { createServer } from "http";
 import { Server } from "socket.io";
 import { Document } from 'mongoose';
+import { v4 as uuid4 } from 'uuid';
 const express = require('express');
 const app = express();
 const cors = require('cors');
@@ -22,12 +23,17 @@ async function run() {
   });
 }
 
+// Express Middleware
+
 app.use(cors({
   origin: 'http://localhost:3002',  // Replace with your client's origin
 }));
+
 app.use(express.json());
 
 const PORT = process.env.ENV_PORT || 3001; // this is updated but no ENV_PORT at the moment
+
+// TypeScript types
 
 interface ServerToClientEvents {
   noArg: () => void;
@@ -50,6 +56,7 @@ interface ClientToServerEvents {
   hello: () => void;
   message: (message: String) => void;
   connect_message: (message: RoomData) => void;
+  session: (message: SessionObject) => void;
 }
 
 interface InterServerEvents {
@@ -59,7 +66,14 @@ interface InterServerEvents {
 interface SocketData {
   name: string;
   age: number;
+  sessionId: string;
 }
+
+interface SessionObject {
+  sessionId: string;
+}
+
+// instantiating new WS server
 
 const io = new Server<
   ServerToClientEvents,
@@ -73,43 +87,69 @@ const io = new Server<
   },
 });
 
-app.get('/', (req: Request, res: Response) => {
-  console.log("you've got mail!");
-  res.send('Nice work')
-});
+
+// WS Server Logic
 
 let reconnect: boolean = false;
 
+let currentSessions: SessionObject[] = []
+
 const fetchMessages = async () => {
-  let messageArr: IMgRequest[] = await MgRequest.find().sort({_id: -1}).limit(5);
+  let messageArr: IMgRequest[] = await MgRequest.find().sort({ _id: -1 }).limit(5);
   return messageArr;
 }
 
+io.use((socket, next) => {
+  const currentSessionID = socket.handshake.auth.sessionId;
+  console.log("Middleware executed");
+  console.log(currentSessionID);
+  console.log(currentSessions);
+
+  // if current session exists (re-connect), find that sessionId from the session
+  if (currentSessionID) {
+    const session = currentSessions.find(obj => obj.sessionId === currentSessionID);
+    if (session) {
+      socket.data.sessionId = session.sessionId;
+      return next();
+    }
+  }
+  let randomID = uuid4();
+
+  socket.data.sessionId = randomID;
+
+  currentSessions.push({ sessionId: randomID });
+
+  next();
+});
+
 io.on('connection', async (socket) => {
   if (reconnect) {
+
     console.log('A user re-connected');
+
     socket.join("room 1");
+
     let messageArr = await fetchMessages();
-    console.log(messageArr);
     messageArr.forEach(message => {
-      console.log(message)
       let msg = message.room.roomData
       socket.emit("connect_message", msg);
     });
-  } else { 
+
+  } else {
     console.log('A user connected first time');
     socket.join("room 1");
+
+    socket.emit("session", {
+      sessionId: socket.data.sessionId,
+    })
   }
-  // check to see if this session_id was recently active 
-  // and if their previous disconnection was intentional
+
 
   socket.on("disconnecting", (reason) => {
-    console.log(socket.rooms); // Set { ... }
-    console.log(reason);
 
     if (reason === "client namespace disconnect") {
       reconnect = true;
-      // push an object with session_id and unintentionalDisconnect 
+      // push an object with session_id and unintentionalDisconnect
     }
   });
 
@@ -118,11 +158,19 @@ io.on('connection', async (socket) => {
   });
 });
 
+
+// Backend API
+
+app.get('/', (req: Request, res: Response) => {
+  console.log("you've got mail!");
+  res.send('Nice work')
+});
+
 app.put('/api/postman', async (req: Request, res: Response) => {
   // accept postman put request
   // publish this request.body data via websocket emit
   const data: string = req.body;
-  console.log(data);
+  console.log(data)
 
   const currentRequest = new MgRequest({
     room: {


### PR DESCRIPTION
Added functionality for a `sessionId` to be generated, stored in `localstorage` on the client, and remain the same value on the server between pressing the disconnect button and re-connecting 

- In `index.ts` on the server:
  - added the `currentSessions` array  on line 95 which is an array of `SessionObject`'s 
    - `SessionObject` is defined as an interface on lines 72 and 73 - they have one property `sessionId` with a value of type String
  - added a new property of `sessionId` on the `socket.data` interface
  - added the `io.use` middleware  starting on line 102 which either sets the `socket.data.sessionId` to a new value (using the uuid library) if this is a new user/connection or retrieves the existing `sessionId` from the `currentSessions`array if this is an existing user/reconnection
  - added a "session" event block on lines 142-144 that only fires if this is a new connection
  
- In `messages.js` on the client:
  - added the `"session"` event listener that sets the `sessionId` value to be sent from the client on re-connection inside the `.auth` attribute and also sets the value of `"sessionId"` in `localstorage` 

- How to test this new functionality: 
  - Upon connection to the server, you can log `localstorage` in your browsers console and this should show you the value of `sessionId` - this should not change throughout your session, even if you press the disconnect button
  - I added `console.log` statements on lines 104-106 of `index.ts` - After the initial output for the new connection - these lines should output the same value after pressing the disconnect button and then reconnecting 